### PR TITLE
Fix locking and unlocking states transitioning back to prior state before new state

### DIFF
--- a/custom_components/kwikset/const.py
+++ b/custom_components/kwikset/const.py
@@ -60,6 +60,13 @@ HISTORY_MAX_RETRY_ATTEMPTS: Final = 2
 # 30 seconds is used by the Matter lock integration as a safe default.
 OPTIMISTIC_TIMEOUT_SECONDS: Final = 30
 
+# Grace period after a lock/unlock state confirmation to prevent stale
+# REST API data from briefly reverting the confirmed state. During this
+# period, coordinator updates that would revert is_locked are suppressed.
+# 15 seconds is long enough for the REST API to reach consistency while
+# short enough that real physical state changes are not masked.
+CONFIRMATION_HOLD_SECONDS: Final = 15
+
 # Limit concurrent API calls per platform to prevent rate limiting
 # Each platform file uses this value to serialize entity operations
 PARALLEL_UPDATES: Final = 1

--- a/custom_components/kwikset/device.py
+++ b/custom_components/kwikset/device.py
@@ -156,6 +156,7 @@ class KwiksetDeviceDataUpdateCoordinator(DataUpdateCoordinator[KwiksetDeviceData
         self._access_code_store_data: dict[str, dict[str, Any]] = access_code_data or {}
         self._device_reported_slots: dict[int, AccessCodeSlotData] = {}
         self._first_refresh_done: bool = False
+        self._preserve_door_status: bool = False
 
     # -------------------------------------------------------------------------
     # API Call Wrapper
@@ -344,9 +345,28 @@ class KwiksetDeviceDataUpdateCoordinator(DataUpdateCoordinator[KwiksetDeviceData
         self._device_reported_slots = self._discover_device_slots(info)
         self._log_access_code_fields(info)
 
+        # Determine door_status from API response
+        door_status = info.get(_KEY_DOOR_STATUS, "Unknown")
+
+        # If a WebSocket event just provided an authoritative door_status,
+        # preserve it instead of using potentially stale REST API data.
+        if self._preserve_door_status:
+            if self.data:
+                preserved_status = self.data.get("door_status", door_status)
+                LOGGER.debug(
+                    "Preserving WebSocket-provided door_status=%s for %s "
+                    "(REST API returned %s)",
+                    preserved_status,
+                    self.device_id,
+                    door_status,
+                )
+                door_status = preserved_status
+            # Always clear the flag after one use, even if no data to preserve
+            self._preserve_door_status = False
+
         return KwiksetDeviceData(
             device_info=info,
-            door_status=info.get(_KEY_DOOR_STATUS, "Unknown"),
+            door_status=door_status,
             battery_percentage=info.get(_KEY_BATTERY),
             model_number=info.get(_KEY_MODEL, "Unknown"),
             serial_number=info.get(_KEY_SERIAL, "Unknown"),
@@ -471,6 +491,7 @@ class KwiksetDeviceDataUpdateCoordinator(DataUpdateCoordinator[KwiksetDeviceData
                 original_door_status,
                 new_door_status,
             )
+            self._preserve_door_status = True  # Protect against stale REST data
             self.hass.async_create_task(self.async_request_refresh(), eager_start=False)
 
     # -------------------------------------------------------------------------

--- a/custom_components/kwikset/lock.py
+++ b/custom_components/kwikset/lock.py
@@ -38,6 +38,7 @@ from homeassistant.core import callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
+from .const import CONFIRMATION_HOLD_SECONDS
 from .const import DOMAIN
 from .const import LOGGER
 from .const import OPTIMISTIC_TIMEOUT_SECONDS
@@ -132,7 +133,7 @@ class KwiksetLock(KwiksetEntity, LockEntity):
     """
 
     # Platinum tier: __slots__ reduces memory footprint
-    __slots__ = ("_optimistic_timer",)
+    __slots__ = ("_confirmation_hold_timer", "_optimistic_timer")
 
     # Bronze tier: has_entity_name - entity is the primary device entity
     # Setting name to None means the entity will use the device name
@@ -143,6 +144,7 @@ class KwiksetLock(KwiksetEntity, LockEntity):
         """Initialize the lock entity."""
         super().__init__("lock", coordinator)
         self._optimistic_timer: asyncio.TimerHandle | None = None
+        self._confirmation_hold_timer: asyncio.TimerHandle | None = None
         # Set initial lock state from coordinator
         self._update_lock_state()
 
@@ -150,31 +152,48 @@ class KwiksetLock(KwiksetEntity, LockEntity):
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator.
 
-        Only reset optimistic state when the expected state is confirmed.
-        This prevents race conditions where a stale poll update arrives
-        before the lock/unlock action is reflected in the API, which would
-        cause the state to briefly show the old state (issue #118).
-
-        - If is_locking is True, only reset when status is "locked"
-        - If is_unlocking is True, only reset when status is "unlocked"
-        - Otherwise, keep the optimistic state until timeout or confirmation
+        State update logic:
+        1. Optimistic confirmation: API confirms expected state → clear optimistic,
+           update lock state, start confirmation hold to prevent stale reverts.
+        2. Optimistic active (not confirmed): Keep optimistic indicators, skip lock
+           state update (is_locking/is_unlocking takes precedence in HA state machine).
+        3. Confirmation hold active: Skip lock state update to prevent stale REST API
+           data from reverting the just-confirmed state. Jammed state always passes.
+        4. Normal: No special state, update lock state from coordinator.
         """
         status = self.coordinator.status
         normalized = _normalize_status(status)
 
-        # Only reset optimistic state when the expected state is confirmed
         if self._attr_is_locking and normalized == _STATUS_LOCKED:
-            # Lock confirmed - reset optimistic state
+            # Lock confirmed — clear optimistic, update state, start hold
             self._reset_optimistic_state(write_state=False)
+            self._update_lock_state()
+            self._start_confirmation_hold()
         elif self._attr_is_unlocking and normalized == _STATUS_UNLOCKED:
-            # Unlock confirmed - reset optimistic state
+            # Unlock confirmed — clear optimistic, update state, start hold
             self._reset_optimistic_state(write_state=False)
-        elif not self._attr_is_locking and not self._attr_is_unlocking:
-            # No optimistic state active - ensure it's reset
-            self._reset_optimistic_state(write_state=False)
-        # else: Keep optimistic state - waiting for expected state confirmation
+            self._update_lock_state()
+            self._start_confirmation_hold()
+        elif self._attr_is_locking or self._attr_is_unlocking:
+            # Optimistic active, not yet confirmed — skip lock state update.
+            # is_locking/is_unlocking takes precedence in HA LockEntity state machine.
+            pass
+        elif self._is_confirmation_hold_active:
+            # Recently confirmed — suppress stale reverts, but allow jammed through
+            if _is_jammed(status):
+                self._cancel_confirmation_hold()
+                self._update_lock_state()
+            else:
+                LOGGER.debug(
+                    "Skipping state update during confirmation hold for %s "
+                    "(API reports %r, holding confirmed state)",
+                    self.entity_id,
+                    status,
+                )
+        else:
+            # Normal — no optimistic state, no hold
+            self._update_lock_state()
 
-        self._update_lock_state()
         super()._handle_coordinator_update()
 
     def _update_lock_state(self) -> None:
@@ -200,6 +219,52 @@ class KwiksetLock(KwiksetEntity, LockEntity):
         )
 
     @callback
+    def _start_confirmation_hold(self) -> None:
+        """Start a hold period after state confirmation.
+
+        Prevents stale REST API data from briefly reverting the
+        just-confirmed lock state. The hold auto-expires after
+        CONFIRMATION_HOLD_SECONDS, at which point normal coordinator
+        updates resume.
+        """
+        self._cancel_confirmation_hold()
+        self._confirmation_hold_timer = self.hass.loop.call_later(
+            CONFIRMATION_HOLD_SECONDS, self._end_confirmation_hold
+        )
+        LOGGER.debug(
+            "Confirmation hold started for %s (%ds)",
+            self.entity_id,
+            CONFIRMATION_HOLD_SECONDS,
+        )
+
+    @callback
+    def _end_confirmation_hold(self) -> None:
+        """End the confirmation hold and sync with coordinator state."""
+        self._confirmation_hold_timer = None
+        self._update_lock_state()
+        self.async_write_ha_state()
+        LOGGER.debug(
+            "Confirmation hold ended for %s, synced with coordinator",
+            self.entity_id,
+        )
+
+    @callback
+    def _cancel_confirmation_hold(self) -> None:
+        """Cancel the confirmation hold timer if active."""
+        timer = self._confirmation_hold_timer
+        if timer and not timer.cancelled():
+            timer.cancel()
+        self._confirmation_hold_timer = None
+
+    @property
+    def _is_confirmation_hold_active(self) -> bool:
+        """Return whether the confirmation hold is currently active."""
+        return (
+            self._confirmation_hold_timer is not None
+            and not self._confirmation_hold_timer.cancelled()
+        )
+
+    @callback
     def _reset_optimistic_state(self, write_state: bool = True) -> None:
         """Reset the optimistic locking/unlocking state.
 
@@ -212,6 +277,7 @@ class KwiksetLock(KwiksetEntity, LockEntity):
             write_state: Whether to write state to HA after reset.
 
         """
+        self._cancel_confirmation_hold()
         if self._optimistic_timer and not self._optimistic_timer.cancelled():
             self._optimistic_timer.cancel()
         self._optimistic_timer = None
@@ -222,6 +288,7 @@ class KwiksetLock(KwiksetEntity, LockEntity):
 
     async def async_will_remove_from_hass(self) -> None:
         """Clean up when entity is being removed."""
+        self._cancel_confirmation_hold()
         self._reset_optimistic_state(write_state=False)
         await super().async_will_remove_from_hass()
 

--- a/tests/test_device_coordinator.py
+++ b/tests/test_device_coordinator.py
@@ -2111,3 +2111,168 @@ class TestSlotParsing:
         assert 3 in result
         assert 5 in result
         assert result[5]["occupied"] is False  # None value = not occupied
+
+
+# =============================================================================
+# Preserve Door Status Tests
+# =============================================================================
+
+
+class TestPreserveDoorStatus:
+    """Tests for the _preserve_door_status flag in the coordinator.
+
+    When a WebSocket event provides an authoritative door_status,
+    the subsequent REST API refresh should not overwrite it with stale data.
+    """
+
+    async def test_preserve_door_status_on_websocket_then_refresh(
+        self,
+        hass: HomeAssistant,
+        mock_config_entry: MagicMock,
+    ) -> None:
+        """Test preserved door_status overrides stale REST API data."""
+        api = MagicMock()
+        api.device = MagicMock()
+        api.device.get_device_info = AsyncMock(return_value=MOCK_DEVICE_INFO)
+        api.device.get_device_history = AsyncMock(
+            return_value={"data": [], "total": 0, "issues": []}
+        )
+
+        coordinator = KwiksetDeviceDataUpdateCoordinator(
+            hass=hass,
+            api_client=api,
+            device_id=MOCK_DEVICE_ID,
+            device_name=MOCK_DEVICE_NAME,
+            update_interval=30,
+            config_entry=mock_config_entry,
+        )
+
+        await coordinator.async_config_entry_first_refresh()
+
+        # Initial state: Locked (from MOCK_DEVICE_INFO)
+        assert coordinator.data["door_status"] == "Locked"
+
+        # Simulate WebSocket event that changed status to Unlocked
+        # (This sets the data directly as handle_realtime_event would)
+        updated = dict(coordinator.data)
+        updated["door_status"] = "Unlocked"
+        coordinator.async_set_updated_data(updated)
+        assert coordinator.data["door_status"] == "Unlocked"
+
+        # Set the preserve flag (as handle_realtime_event would)
+        coordinator._preserve_door_status = True
+
+        # REST API still returns stale "Locked"
+        api.device.get_device_info = AsyncMock(return_value=MOCK_DEVICE_INFO)
+
+        # Trigger a refresh and capture the return value
+        result = await coordinator._async_update_data()
+
+        # The returned door_status should be preserved as "Unlocked"
+        assert result["door_status"] == "Unlocked"
+
+        # Flag should be cleared after use
+        assert coordinator._preserve_door_status is False
+
+    async def test_preserve_door_status_flag_set_by_realtime_event(
+        self,
+        hass: HomeAssistant,
+        mock_config_entry: MagicMock,
+    ) -> None:
+        """Test handle_realtime_event sets _preserve_door_status on door change."""
+        api = MagicMock()
+        api.device = MagicMock()
+        api.device.get_device_info = AsyncMock(return_value=MOCK_DEVICE_INFO)
+        api.device.get_device_history = AsyncMock(
+            return_value={"data": [], "total": 0, "issues": []}
+        )
+
+        coordinator = KwiksetDeviceDataUpdateCoordinator(
+            hass=hass,
+            api_client=api,
+            device_id=MOCK_DEVICE_ID,
+            device_name=MOCK_DEVICE_NAME,
+            update_interval=30,
+            config_entry=mock_config_entry,
+        )
+
+        await coordinator.async_config_entry_first_refresh()
+
+        # Initially False
+        assert coordinator._preserve_door_status is False
+
+        # Simulate door status change via websocket
+        event_data = {
+            "devicestatus": "Unlocked",
+        }
+
+        with patch.object(coordinator, "async_request_refresh"):
+            coordinator.handle_realtime_event(event_data)
+
+        # Flag should be set because door status changed
+        assert coordinator._preserve_door_status is True
+
+    async def test_preserve_door_status_not_set_without_change(
+        self,
+        hass: HomeAssistant,
+        mock_config_entry: MagicMock,
+    ) -> None:
+        """Test handle_realtime_event does not set flag when door status unchanged."""
+        api = MagicMock()
+        api.device = MagicMock()
+        api.device.get_device_info = AsyncMock(return_value=MOCK_DEVICE_INFO)
+        api.device.get_device_history = AsyncMock(
+            return_value={"data": [], "total": 0, "issues": []}
+        )
+
+        coordinator = KwiksetDeviceDataUpdateCoordinator(
+            hass=hass,
+            api_client=api,
+            device_id=MOCK_DEVICE_ID,
+            device_name=MOCK_DEVICE_NAME,
+            update_interval=30,
+            config_entry=mock_config_entry,
+        )
+
+        await coordinator.async_config_entry_first_refresh()
+
+        # Initially Locked, send event without door status change
+        event_data = {
+            "batterypercentage": 50,
+        }
+
+        coordinator.handle_realtime_event(event_data)
+
+        # Flag should NOT be set (no door status change)
+        assert coordinator._preserve_door_status is False
+
+    async def test_preserve_door_status_no_existing_data(
+        self,
+        hass: HomeAssistant,
+        mock_config_entry: MagicMock,
+    ) -> None:
+        """Test _preserve_door_status with no existing data uses API data."""
+        api = MagicMock()
+        api.device = MagicMock()
+        api.device.get_device_info = AsyncMock(return_value=MOCK_DEVICE_INFO)
+
+        coordinator = KwiksetDeviceDataUpdateCoordinator(
+            hass=hass,
+            api_client=api,
+            device_id=MOCK_DEVICE_ID,
+            device_name=MOCK_DEVICE_NAME,
+            update_interval=30,
+            config_entry=mock_config_entry,
+        )
+
+        # Set preserve flag before first refresh (no existing data)
+        coordinator._preserve_door_status = True
+
+        # First refresh — self.data is None at this point
+        result = await coordinator._async_update_data()
+
+        # Should use API data since there's no previous data to preserve
+        assert result["door_status"] == "Locked"
+
+        # Flag should still be cleared even though no data was preserved
+        assert coordinator._preserve_door_status is False

--- a/tests/test_entity_platforms.py
+++ b/tests/test_entity_platforms.py
@@ -1656,3 +1656,323 @@ class TestHomeSensorDescriptions:
         desc = sensor_module.HOME_SENSOR_DESCRIPTIONS[0]
         value = desc.value_fn(mock_coordinator)
         assert value == 0
+
+
+# =============================================================================
+# Lock Confirmation Hold Tests
+# =============================================================================
+
+
+@pytest.mark.skipif(not _can_import_lock_module(), reason=LOCK_SKIP_REASON)
+class TestKwiksetLockConfirmationHold:
+    """Tests for the KwiksetLock confirmation hold functionality.
+
+    The confirmation hold prevents stale REST API data from briefly
+    reverting the just-confirmed lock state after a lock/unlock action.
+    """
+
+    def test_confirmation_hold_starts_on_lock_confirmation(
+        self, lock_module, mock_coordinator_unlocked: MagicMock
+    ) -> None:
+        """Test confirmation hold starts when locking is confirmed."""
+        lock = lock_module.KwiksetLock(mock_coordinator_unlocked)
+        lock.hass = MagicMock()
+        mock_hold_timer = MagicMock()
+        lock.hass.loop = MagicMock()
+        lock.hass.loop.call_later = MagicMock(return_value=mock_hold_timer)
+        lock.async_write_ha_state = MagicMock()
+
+        # Simulate locking optimistic state
+        lock._attr_is_locking = True
+        lock._attr_is_unlocking = False
+        mock_timer = MagicMock()
+        mock_timer.cancelled.return_value = False
+        lock._optimistic_timer = mock_timer
+
+        # Coordinator now reports Locked (confirmation)
+        mock_coordinator_unlocked.status = "Locked"
+        lock._handle_coordinator_update()
+
+        # Optimistic state should be cleared
+        assert lock._attr_is_locking is False
+        assert lock._attr_is_unlocking is False
+
+        # Lock state should be updated
+        assert lock._attr_is_locked is True
+
+        # Confirmation hold timer should be started
+        assert lock._confirmation_hold_timer is not None
+
+    def test_confirmation_hold_starts_on_unlock_confirmation(
+        self, lock_module, mock_coordinator: MagicMock
+    ) -> None:
+        """Test confirmation hold starts when unlocking is confirmed."""
+        lock = lock_module.KwiksetLock(mock_coordinator)
+        lock.hass = MagicMock()
+        mock_hold_timer = MagicMock()
+        lock.hass.loop = MagicMock()
+        lock.hass.loop.call_later = MagicMock(return_value=mock_hold_timer)
+        lock.async_write_ha_state = MagicMock()
+
+        # Simulate unlocking optimistic state
+        lock._attr_is_locking = False
+        lock._attr_is_unlocking = True
+        mock_timer = MagicMock()
+        mock_timer.cancelled.return_value = False
+        lock._optimistic_timer = mock_timer
+
+        # Coordinator now reports Unlocked (confirmation)
+        mock_coordinator.status = "Unlocked"
+        lock._handle_coordinator_update()
+
+        # Optimistic state should be cleared
+        assert lock._attr_is_locking is False
+        assert lock._attr_is_unlocking is False
+
+        # Lock state should be updated
+        assert lock._attr_is_locked is False
+
+        # Confirmation hold timer should be started
+        assert lock._confirmation_hold_timer is not None
+
+    def test_confirmation_hold_prevents_stale_revert_after_lock(
+        self, lock_module, mock_coordinator: MagicMock
+    ) -> None:
+        """Test confirmation hold prevents stale Unlocked from reverting Locked state."""
+        lock = lock_module.KwiksetLock(mock_coordinator)
+        lock.hass = MagicMock()
+        mock_hold_timer = MagicMock()
+        mock_hold_timer.cancelled.return_value = False
+        lock.hass.loop = MagicMock()
+        lock.hass.loop.call_later = MagicMock(return_value=mock_hold_timer)
+        lock.async_write_ha_state = MagicMock()
+
+        # Step 1: Simulate lock confirmation
+        lock._attr_is_locking = True
+        lock._attr_is_unlocking = False
+        mock_timer = MagicMock()
+        mock_timer.cancelled.return_value = False
+        lock._optimistic_timer = mock_timer
+        mock_coordinator.status = "Locked"
+        lock._handle_coordinator_update()
+
+        # State is now locked with confirmation hold active
+        assert lock._attr_is_locked is True
+        assert lock._is_confirmation_hold_active
+
+        # Step 2: Stale REST API data reports Unlocked
+        mock_coordinator.status = "Unlocked"
+        lock._handle_coordinator_update()
+
+        # State should still be Locked (hold prevents revert)
+        assert lock._attr_is_locked is True
+
+    def test_confirmation_hold_prevents_stale_revert_after_unlock(
+        self, lock_module, mock_coordinator_unlocked: MagicMock
+    ) -> None:
+        """Test confirmation hold prevents stale Locked from reverting Unlocked state."""
+        lock = lock_module.KwiksetLock(mock_coordinator_unlocked)
+        lock.hass = MagicMock()
+        mock_hold_timer = MagicMock()
+        mock_hold_timer.cancelled.return_value = False
+        lock.hass.loop = MagicMock()
+        lock.hass.loop.call_later = MagicMock(return_value=mock_hold_timer)
+        lock.async_write_ha_state = MagicMock()
+
+        # Step 1: Simulate unlock confirmation
+        lock._attr_is_locking = False
+        lock._attr_is_unlocking = True
+        mock_timer = MagicMock()
+        mock_timer.cancelled.return_value = False
+        lock._optimistic_timer = mock_timer
+        mock_coordinator_unlocked.status = "Unlocked"
+        lock._handle_coordinator_update()
+
+        # State is now unlocked with confirmation hold active
+        assert lock._attr_is_locked is False
+        assert lock._is_confirmation_hold_active
+
+        # Step 2: Stale REST API data reports Locked
+        mock_coordinator_unlocked.status = "Locked"
+        lock._handle_coordinator_update()
+
+        # State should still be Unlocked (hold prevents revert)
+        assert lock._attr_is_locked is False
+
+    def test_confirmation_hold_allows_jammed_through(
+        self, lock_module, mock_coordinator: MagicMock
+    ) -> None:
+        """Test jammed status passes through during confirmation hold."""
+        lock = lock_module.KwiksetLock(mock_coordinator)
+        lock.hass = MagicMock()
+        mock_hold_timer = MagicMock()
+        mock_hold_timer.cancelled.return_value = False
+        lock.hass.loop = MagicMock()
+        lock.hass.loop.call_later = MagicMock(return_value=mock_hold_timer)
+        lock.async_write_ha_state = MagicMock()
+
+        # Step 1: Simulate lock confirmation to start hold
+        lock._attr_is_locking = True
+        lock._attr_is_unlocking = False
+        mock_timer = MagicMock()
+        mock_timer.cancelled.return_value = False
+        lock._optimistic_timer = mock_timer
+        mock_coordinator.status = "Locked"
+        lock._handle_coordinator_update()
+
+        assert lock._is_confirmation_hold_active
+
+        # Step 2: Jammed status arrives during hold
+        mock_coordinator.status = "Jammed"
+        lock._handle_coordinator_update()
+
+        # Jammed should pass through and cancel the hold
+        assert lock._attr_is_jammed is True
+        assert lock._attr_is_locked is None
+        assert not lock._is_confirmation_hold_active
+
+    def test_confirmation_hold_expiry_syncs_state(
+        self, lock_module, mock_coordinator: MagicMock
+    ) -> None:
+        """Test _end_confirmation_hold syncs state and writes HA state."""
+        lock = lock_module.KwiksetLock(mock_coordinator)
+        lock.hass = MagicMock()
+        lock.async_write_ha_state = MagicMock()
+
+        # Set up a mock hold timer
+        mock_hold_timer = MagicMock()
+        mock_hold_timer.cancelled.return_value = False
+        lock._confirmation_hold_timer = mock_hold_timer
+
+        # Directly call _end_confirmation_hold
+        lock._end_confirmation_hold()
+
+        # Timer should be cleared
+        assert lock._confirmation_hold_timer is None
+
+        # async_write_ha_state should be called to push state update
+        lock.async_write_ha_state.assert_called_once()
+
+    async def test_confirmation_hold_cancelled_on_removal(
+        self, lock_module, mock_coordinator: MagicMock
+    ) -> None:
+        """Test confirmation hold timer is cancelled when entity is removed."""
+        lock = lock_module.KwiksetLock(mock_coordinator)
+        lock.hass = MagicMock()
+        lock.async_write_ha_state = MagicMock()
+
+        # Start a confirmation hold
+        mock_hold_timer = MagicMock()
+        mock_hold_timer.cancelled.return_value = False
+        lock._confirmation_hold_timer = mock_hold_timer
+
+        # Also set an optimistic timer
+        mock_opt_timer = MagicMock()
+        mock_opt_timer.cancelled.return_value = False
+        lock._optimistic_timer = mock_opt_timer
+
+        # Remove entity
+        await lock.async_will_remove_from_hass()
+
+        # Both timers should be cancelled
+        mock_hold_timer.cancel.assert_called()
+        assert lock._confirmation_hold_timer is None
+
+    def test_optimistic_state_skips_lock_state_update(
+        self, lock_module, mock_coordinator_unlocked: MagicMock
+    ) -> None:
+        """Test optimistic state skips lock state update when not confirmed."""
+        lock = lock_module.KwiksetLock(mock_coordinator_unlocked)
+        lock.hass = MagicMock()
+        lock.async_write_ha_state = MagicMock()
+
+        # Set is_locked to False initially (unlocked)
+        assert lock._attr_is_locked is False
+
+        # Simulate locking optimistic state
+        lock._attr_is_locking = True
+        lock._attr_is_unlocking = False
+        mock_timer = MagicMock()
+        mock_timer.cancelled.return_value = False
+        lock._optimistic_timer = mock_timer
+
+        # Coordinator still reports Unlocked (stale)
+        mock_coordinator_unlocked.status = "Unlocked"
+        lock._handle_coordinator_update()
+
+        # is_locking should be preserved, is_locked should NOT have been
+        # updated to False by _update_lock_state (it was already False)
+        assert lock._attr_is_locking is True
+        # Timer should NOT be cancelled
+        mock_timer.cancel.assert_not_called()
+
+    def test_no_hold_during_normal_updates(
+        self, lock_module, mock_coordinator: MagicMock
+    ) -> None:
+        """Test normal coordinator updates work without hold interference."""
+        lock = lock_module.KwiksetLock(mock_coordinator)
+        lock.hass = MagicMock()
+        lock.async_write_ha_state = MagicMock()
+
+        # No optimistic state, no hold
+        assert not lock._attr_is_locking
+        assert not lock._attr_is_unlocking
+        assert not lock._is_confirmation_hold_active
+
+        # Coordinator reports Locked
+        mock_coordinator.status = "Locked"
+        lock._handle_coordinator_update()
+        assert lock._attr_is_locked is True
+
+        # Coordinator reports Unlocked
+        mock_coordinator.status = "Unlocked"
+        lock._handle_coordinator_update()
+        assert lock._attr_is_locked is False
+
+        # No hold should have been started
+        assert not lock._is_confirmation_hold_active
+
+    def test_full_lock_state_transition_no_revert(
+        self, lock_module, mock_coordinator_unlocked: MagicMock
+    ) -> None:
+        """Test full lock state transition: unlocked → locking → confirmed → stale → still locked."""
+        lock = lock_module.KwiksetLock(mock_coordinator_unlocked)
+        lock.hass = MagicMock()
+        mock_hold_timer = MagicMock()
+        mock_hold_timer.cancelled.return_value = False
+        lock.hass.loop = MagicMock()
+        lock.hass.loop.call_later = MagicMock(return_value=mock_hold_timer)
+        lock.async_write_ha_state = MagicMock()
+
+        # Initial state: unlocked
+        assert lock._attr_is_locked is False
+
+        # Step 1: User initiates lock → optimistic locking state
+        lock._attr_is_locking = True
+        mock_timer = MagicMock()
+        mock_timer.cancelled.return_value = False
+        lock._optimistic_timer = mock_timer
+
+        # Step 2: WebSocket confirms Locked
+        mock_coordinator_unlocked.status = "Locked"
+        lock._handle_coordinator_update()
+
+        # State: locked, optimistic cleared, hold started
+        assert lock._attr_is_locked is True
+        assert lock._attr_is_locking is False
+        assert lock._is_confirmation_hold_active
+
+        # Step 3: Stale REST API data reports Unlocked
+        mock_coordinator_unlocked.status = "Unlocked"
+        lock._handle_coordinator_update()
+
+        # State should still be Locked (hold prevents revert)
+        assert lock._attr_is_locked is True
+
+        # Step 4: Hold expires — sync with coordinator
+        # Coordinator now reports Locked again (eventually consistent)
+        mock_coordinator_unlocked.status = "Locked"
+        lock._end_confirmation_hold()
+
+        assert lock._attr_is_locked is True
+        assert not lock._is_confirmation_hold_active


### PR DESCRIPTION
This update introduces a grace period after a lock/unlock state confirmation to prevent stale REST API data from briefly reverting the confirmed state. A new flag is added to preserve the door status when a WebSocket event provides an authoritative update, ensuring that subsequent REST API refreshes do not overwrite it with outdated information. This change addresses the issue where the locking and unlocking states would incorrectly transition back to a prior state, causing automation to fire incorrectly.

Fixes #118