### PR TITLE
fix(deps): bump aiokwikset to 0.7.3 to fix config flow hang (#122)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.7.1] - 2026-04-27
+
+### Fixed
+- **Config flow hang on slow/unreachable Cognito** ([#122](https://github.com/explosivo22/kwikset-ha/issues/122)): When AWS Cognito was slow or a network path was broken, the synchronous boto3 calls inside `aiokwikset` would block a Home Assistant executor thread for ~10 minutes (boto3's default 60s connect/read timeouts × 5 retries), leaving the config flow spinning indefinitely and producing a `SyncWorker is still running at shutdown` warning pointing into `_authenticate_srp`. The `asyncio.timeout` wrapper around `async_login` could not cancel the in-flight executor work.
+
+### Changed
+- **aiokwikset**: Bumped to **0.7.3**, which:
+  - Caps boto3 Cognito calls at `connect_timeout=10s`, `read_timeout=15s`, `max_attempts=2` — worst-case auth attempt is now ~50s instead of ~10 min.
+  - Surfaces botocore `ConnectTimeoutError`, `ReadTimeoutError`, and `EndpointConnectionError` as `KwiksetConnectionError` from all auth code paths (login, MFA response, custom-challenge code request, token refresh) so the integration's existing connection-error handling (`cannot_connect`, `ConfigEntryNotReady`) kicks in instead of `unknown`.
+
+---
+
 ## [0.4.0] - 2025-12-03
 
 ### ⚠️ BREAKING CHANGES

--- a/custom_components/kwikset/manifest.json
+++ b/custom_components/kwikset/manifest.json
@@ -7,6 +7,6 @@
   "iot_class": "cloud_push",
   "issue_tracker": "https://github.com/explosivo22/kwikset-ha/issues",
   "quality_scale": "platinum",
-  "requirements": ["aiokwikset==0.7.2"],
-  "version": "0.7.0"
+  "requirements": ["aiokwikset==0.7.3"],
+  "version": "0.7.1"
 }

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -4,7 +4,7 @@ pytest-asyncio>=0.23.0
 pytest-homeassistant-custom-component>=0.13.0
 
 # Integration dependencies
-aiokwikset==0.6.2
+aiokwikset==0.7.3
 
 # Lint and type checking (matches CI workflow)
 ruff>=0.8.0


### PR DESCRIPTION
## Summary

[#122](https://github.com/explosivo22/kwikset-ha/issues/122) — config flow hangs for ~10 minutes when Cognito is slow or unreachable, with a `SyncWorker is still running at shutdown` warning pointing into `_authenticate_srp`.

## Root cause

The pycognito/boto3 auth path runs synchronous network I/O on a Home Assistant executor thread. boto3's defaults (60s connect timeout, 60s read timeout, 5 retry attempts) mean a flaky Cognito connection blocks the worker thread for up to ~10 minutes — and the existing `async with asyncio.timeout(AUTH_CALL_TIMEOUT_SECONDS)` wrapper around `async_login` cannot cancel the in-flight executor work, so the orphaned thread keeps running until boto finally returns.

## Fix

Bumps `aiokwikset` to **0.7.3** ([explosivo22/aiokwikset#32](https://github.com/explosivo22/aiokwikset/pull/32)), which:

1. **Bounded boto3 timeouts** — Configures the Cognito client with `connect_timeout=10s`, `read_timeout=15s`, `max_attempts=2`. Worst-case auth attempt is now ~50s instead of ~10 min.
2. **Connection-error mapping** — Surfaces botocore `ConnectTimeoutError`, `ReadTimeoutError`, and `EndpointConnectionError` as `KwiksetConnectionError` from all four auth code paths (login, MFA response, custom-challenge code request, token refresh). The integration's existing handlers for `KwiksetConnectionError` (in `config_flow._async_authenticate` → `cannot_connect`, in `__init__` → `ConfigEntryNotReady`) now correctly trigger retry/backoff instead of falling through to `unknown`.
3. **(Available, not adopted yet)** Optional injectable `API.executor` to use a dedicated `ThreadPoolExecutor`. Not used here — HA's default executor handles the short-lived auth calls fine; can revisit if contention becomes an issue.

## Changes

- `manifest.json`: `aiokwikset==0.7.2` → `aiokwikset==0.7.3`, integration version `0.7.0` → `0.7.1`
- `requirements_test.txt`: `aiokwikset==0.6.2` → `aiokwikset==0.7.3` (was stale)
- `CHANGELOG.md`: Added `[0.7.1]` entry

## Verification

- `ruff check` ✅
- `ruff format --check` ✅
- `pytest tests/ -q` → **452 passed**